### PR TITLE
Adjust the feeling of the speed of the scroll

### DIFF
--- a/scrolly-photos.js
+++ b/scrolly-photos.js
@@ -37,7 +37,7 @@ class ScrollyPhotos extends HTMLElement {
     
     .scrolly-photo-container .step {
       font-size: 2rem;
-      height: 50vh;
+      height: 90vh;
     }
   </style>
   `


### PR DESCRIPTION
Right now the photos feel like they fly by so to make it feel like each one is on the screen for longer I made each `.scrolly-photo-container .step` have `90vh` for height instead of `50vh`.

This new value feels like a more reasonable default but it would be nice to have control over this value through the attributes of a `<scrolly-photos>`.