### PR TITLE
Add a version for images that gets printed

### DIFF
--- a/scrolly-photos.js
+++ b/scrolly-photos.js
@@ -39,6 +39,20 @@ class ScrollyPhotos extends HTMLElement {
       font-size: 2rem;
       height: 90vh;
     }
+
+    .photos-for-print {
+      display: none;
+    }
+
+    @media print {
+      .scrolly-photo-container {
+        display: none;
+      }
+  
+      .photos-for-print {
+        display: block;
+      }
+    }
   </style>
   `
 
@@ -60,11 +74,14 @@ class ScrollyPhotos extends HTMLElement {
         const photoContainer = document.createElement('div')
         const photosDiv = document.createElement('div')
         const stepContainer = document.createElement('div')
+        const photoForPrintContainer = document.createElement('div')
+
 
         scrollyContainer.classList.add('scrolly-photo-container')
         photoContainer.classList.add('photo-container')
         photosDiv.classList.add('photos')
         photosDiv.style.setProperty('--photo-count', photos.length)
+        photoForPrintContainer.classList.add('photos-for-print')
 
         photos.forEach(photo => {
             const d = document.createElement('div')
@@ -77,11 +94,25 @@ class ScrollyPhotos extends HTMLElement {
             const step = document.createElement('div')
             step.classList.add('step')
 
+            const img = document.createElement('img')
+            img.setAttribute('src', photo.src)
+            img.setAttribute('alt', photo.alt)
+
+            const figure = document.createElement('figure')
+            const caption = document.createElement('figcaption')
+
+            caption.innerText = photo.alt
+
+            figure.appendChild(img)
+            figure.appendChild(caption)
+            photoForPrintContainer.appendChild(figure)
+
             stepContainer.appendChild(step)
         })
 
         shadow.innerHTML = s
         shadow.appendChild(scrollyContainer)
+        shadow.appendChild(photoForPrintContainer)
 
         photoContainer.appendChild(photosDiv)
         scrollyContainer.appendChild(photoContainer)

--- a/scrolly-photos.test.js
+++ b/scrolly-photos.test.js
@@ -75,3 +75,22 @@ test(`the photos scroll left as reader scrolls down`, async({ page }) => {
     expect(translateXPropertyValue).toContain('-');
     expect(translateXPropertyValue).toContain('vw');
 });
+
+
+test(`the photos get printed`, async({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState()
+    await page.emulateMedia({ media: 'print' });
+
+    const counts = await page.evaluate(() => {
+        const imgs = document.querySelectorAll('scrolly-photos img')
+        const divs = document.querySelector('scrolly-photos').shadowRoot.querySelectorAll('img')
+
+        return {
+            imgs: imgs.length,
+            divs: divs.length
+        }
+    })
+
+    expect(counts.imgs).toBe(counts.divs);
+});


### PR DESCRIPTION
We create a bunch of `<div>` elements and set the original image to the background image in CSS so that they end up full screen. But background images don't get printed in CSS so when a person tries to print a page that uses `<scrolly-photos>` there is just a bunch of blank white space. This is captured in #7.

This adds functionality (and a test) for `<img>` elements to also be created and only displayed when `@media print`.